### PR TITLE
enable jbang dimension-ui

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,15 @@
+{
+  "aliases": {
+    "dimension-ui": {
+      "script-ref": "https://github.com/akardapolov/dimension-ui/releases/download/25.12.2/dimension-ui-25.12.2-app.jar",
+      "runtime-options": [
+        "-Xmx2024m"
+      ],
+      "properties": {
+        "LaF": "light",
+        "file.encoding": "UTF8"
+      },
+      "java": "25+"
+    }
+  }
+}


### PR DESCRIPTION
When committed users who have installed jbang (or use its one liner runner) can do:

`jbang dimension-ui@akardapolov/dimension-ui`

and it will run with right version of java as needed.

You can also do `jbang app install dimension-ui@akardapolov/dimension-ui` and it will add `dimension-ui` command to PATH

should be the easiest and fastest way to try it out and run dimension-ui.

Notes:
1. if you instead put this in a new repo called akardapolov/jbang-catalog the name would just be: `dimension-ui@akardapolov`
2. if the jar was in maven central or attached to release with a stable name, i.e. dimension-ui.jar you wouldn't need to update this catalog to get very latest.
